### PR TITLE
Email verification and password reset

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -6,5 +6,12 @@ DB_PASSWORD=password
 DB_HOST=host
 DB_PORT=port
 
+EMAIL_BACKEND=backend
+EMAIL_HOST=host
+EMAIL_USE_SSL=ssl
+EMAIL_PORT=port
+EMAIL_HOST_USER=email
+EMAIL_HOST_PASSWORD=password
+
 # Optional for dev: May choose not to include this variable in your .env.dev file
 SENTRY_DSN=dsn

--- a/api/apps/user/urls.py
+++ b/api/apps/user/urls.py
@@ -1,6 +1,13 @@
 from django.urls import path, include
 
+from .views import ActivateUser
+
 user_urls = [
+    path(
+        "api/v1/auth/users/activate/<uid>/<token>",
+        ActivateUser.as_view({"get": "activation"}),
+        name="activation",
+    ),
     path("api/v1/auth/", include("djoser.urls")),
     path("api/v1/auth/", include("djoser.urls.authtoken")),
 ]

--- a/api/apps/user/views.py
+++ b/api/apps/user/views.py
@@ -1,0 +1,17 @@
+from djoser.views import UserViewSet
+from rest_framework import status
+from rest_framework.response import Response
+
+
+class ActivateUser(UserViewSet):
+    def get_serializer(self, *args, **kwargs):
+        serializer_class = self.get_serializer_class()
+        kwargs.setdefault("context", self.get_serializer_context())
+
+        kwargs["data"] = {"uid": self.kwargs["uid"], "token": self.kwargs["token"]}
+
+        return serializer_class(*args, **kwargs)
+
+    def activation(self, request, uid, token, *args, **kwargs):
+        super().activation(request, *args, **kwargs)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/api/settings/base.py
+++ b/api/settings/base.py
@@ -99,6 +99,8 @@ REST_FRAMEWORK = {
 DJOSER = {
     "USER_ID_FIELD": "email",
     "LOGIN_FIELD": "email",
+    "SEND_ACTIVATION_EMAIL": True,
+    "ACTIVATION_URL": "api/v1/auth/users/activate/{uid}/{token}",
     "SERIALIZERS": {"token": "api.apps.user.serializers.CustomTokenSerializer"},
     "PERMISSIONS": {"user_list": ["rest_framework.permissions.IsAdminUser"]},
 }

--- a/api/settings/base.py
+++ b/api/settings/base.py
@@ -101,6 +101,7 @@ DJOSER = {
     "LOGIN_FIELD": "email",
     "SEND_ACTIVATION_EMAIL": True,
     "ACTIVATION_URL": "api/v1/auth/users/activate/{uid}/{token}",
+    "PASSWORD_RESET_CONFIRM_URL": "api/v1/auth/users/password_reset/{uid}/{token}",
     "SERIALIZERS": {"token": "api.apps.user.serializers.CustomTokenSerializer"},
     "PERMISSIONS": {"user_list": ["rest_framework.permissions.IsAdminUser"]},
 }


### PR DESCRIPTION
- Configure activation and password reset URLs
- Modify email activation endpoint to allow GET requests
- Newly registered accounts will be flagged as inactive until email activation link is clicked
- Closes #5 